### PR TITLE
Fix match card corrupt display on certain browser 

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,6 @@ module.exports = {
     content: ['./app/**/*.{js,ts,jsx,tsx}', './pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
     theme: {
         extend: {
-
             colors: {
                 pmpink: {
                     500: '#fce5f3',
@@ -59,7 +58,6 @@ module.exports = {
                 flash: 'flash 1s steps(1, end) infinite',
                 flip: 'flip 1s ease-in-out infinite',
                 'pulse-glow': 'pulse-glow 1s infinite alternate',
-
             },
         },
     },
@@ -71,9 +69,6 @@ module.exports = {
                 },
                 '.transform-3d': {
                     'transform-style': 'preserve-3d',
-                },
-                '.rotate-y-half': {
-                    transform: 'rotateY(0turn)',
                 },
                 '.rotate-y-half': {
                     transform: 'rotateY(0.5turn)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -75,6 +75,7 @@ module.exports = {
                 },
                 '.backface-hidden': {
                     'backface-visibility': 'hidden',
+                    '-webkit-backface-visibility': 'hidden',
                 },
             };
             addUtilities(newUtilities, ['responsive']);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -70,12 +70,14 @@ module.exports = {
                 '.transform-3d': {
                     'transform-style': 'preserve-3d',
                 },
+                '.rotate-y-0': {
+                    transform: 'rotateY(0turn)',
+                },
                 '.rotate-y-half': {
-                    transform: 'rotateY(0.5turn)',
+                    transform: 'rotateY(0.5turn) translateZ(1px)',
                 },
                 '.backface-hidden': {
                     'backface-visibility': 'hidden',
-                    '-webkit-backface-visibility': 'hidden',
                 },
             };
             addUtilities(newUtilities, ['responsive']);


### PR DESCRIPTION
### Summary <!-- Please provide an overview of the changes made -->

Finished working on:
Fixing match card corrupt display on certain browser.

Turns out that the reason why it bahaved so differently is the rendering strategies that different browsers took for overlapping elements. For some browsers, a strict overlap results in both element being render despite having 'backface-visibility': 'hidden'.

